### PR TITLE
fix: load env token without blocking initialization

### DIFF
--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/storage.js
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/storage.js
@@ -1,4 +1,4 @@
-document.addEventListener("DOMContentLoaded", async () => {
+document.addEventListener("DOMContentLoaded", () => {
   /* ─── Cloudflare‑only setup (no VPS) ───────────────────────────── */
   const USE_LOCAL_FALLBACK = false;              // set true only for offline dev
   /* visitor‑counter cache */
@@ -12,16 +12,19 @@ document.addEventListener("DOMContentLoaded", async () => {
   const defaultModelPreference = localStorage.getItem("defaultModelPreference") || "unity";
 
   let envToken = "";
-  try {
-    const res = await fetch(".env");
-    if (res.ok) {
-      const text = await res.text();
-      const match = text.match(/^POLLINATIONS_API_TOKEN\s*=\s*(.+)$/m);
-      if (match) envToken = match[1].trim();
+  (async () => {
+    try {
+      const res = await fetch(".env");
+      if (res.ok) {
+        const text = await res.text();
+        const match = text.match(/^POLLINATIONS_API_TOKEN\s*=\s*(.+)$/m);
+        if (match) envToken = match[1].trim();
+      }
+    } catch (e) {
+      console.warn("Unable to load .env token", e);
     }
-  } catch (e) {
-    console.warn("Unable to load .env token", e);
-  }
+    document.dispatchEvent(new Event("envTokenLoaded"));
+  })();
 
   if (!localStorage.getItem("currentSessionId")) {
     const newSession = createSession("New Chat");

--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/ui.js
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/ui.js
@@ -214,7 +214,12 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
             });
     }
-    fetchPollinationsModels();
+    const initModelFetch = () => fetchPollinationsModels();
+    if (Storage.getToken()) {
+        initModelFetch();
+    } else {
+        document.addEventListener("envTokenLoaded", initModelFetch, { once: true });
+    }
 
     newSessionBtn.addEventListener("click", () => {
         const newSess = Storage.createSession("New Chat");


### PR DESCRIPTION
## Summary
- load the Pollinations API token without awaiting during DOM ready
- notify the UI once the token is fetched and wait before requesting models

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c04db5f7dc8329ad44c1d2d6c08bc5