### PR TITLE
Remove Unity-specific defaults

### DIFF
--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/chat-init.js
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/chat-init.js
@@ -516,7 +516,7 @@ document.addEventListener("DOMContentLoaded", () => {
             lastUserMsg.includes("picture") || 
             imagePatterns.some(p => p.pattern.test(lastUserMsg))
         );
-        const selectedModel = modelSelect.value || currentSession.model || "unity";
+        const selectedModel = modelSelect.value || currentSession.model || modelSelect.options[0]?.value;
         const nonce = Date.now().toString() + Math.random().toString(36).substring(2);
         const body = { messages, model: selectedModel, nonce };
         let apiUrl = `https://text.pollinations.ai/openai`;

--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/chat-storage.js
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/chat-storage.js
@@ -550,7 +550,7 @@ document.addEventListener("DOMContentLoaded", () => {
             lastUserMsg.includes("picture") || 
             imagePatterns.some(p => p.pattern.test(lastUserMsg))
         );
-        const selectedModel = modelSelect.value || currentSession.model || "unity";
+        const selectedModel = modelSelect.value || currentSession.model || modelSelect.options[0]?.value;
         const nonce = Date.now().toString() + Math.random().toString(36).substring(2);
         const body = { messages, model: selectedModel, nonce };
         let apiUrl = `https://text.pollinations.ai/openai`;

--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/screensaver.js
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/screensaver.js
@@ -147,7 +147,7 @@ document.addEventListener("DOMContentLoaded", () => {
         ];
         const seed = generateSeed();
         const textModelSelect = document.getElementById("model-select");
-        const selectedModel = textModelSelect?.value || (window.Storage?.getCurrentSession?.().model) || "unity";
+        const selectedModel = textModelSelect?.value || window.Storage?.getCurrentSession?.().model || textModelSelect?.options?.[0]?.value;
 
         const body = { messages, model: selectedModel, nonce: Date.now().toString() + Math.random().toString(36).substring(2) };
         let apiUrl = `https://text.pollinations.ai/openai?seed=${seed}`;

--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/storage.js
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/storage.js
@@ -9,7 +9,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const sessionListEl = document.getElementById("session-list");
   let sessions = loadSessions();
-  const defaultModelPreference = localStorage.getItem("defaultModelPreference") || "unity";
+  const defaultModelPreference = localStorage.getItem("defaultModelPreference") || "";
 
   let envToken = "";
   (async () => {
@@ -61,7 +61,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function getDefaultModel() {
-    return localStorage.getItem("defaultModelPreference") || "unity";
+    return localStorage.getItem("defaultModelPreference") || "";
   }
 
   function setDefaultModel(modelName) {

--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/ui.js
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/ui.js
@@ -163,10 +163,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
                 if (!hasValidModel) {
                     const fallbackOpt = document.createElement("option");
-                    fallbackOpt.value = "unity";
-                    fallbackOpt.textContent = "unity";
+                    fallbackOpt.value = "";
+                    fallbackOpt.textContent = "No models available";
                     modelSelect.appendChild(fallbackOpt);
-                    modelSelect.value = "unity";
                 }
 
                 const currentSession = Storage.getCurrentSession();
@@ -183,11 +182,8 @@ document.addEventListener("DOMContentLoaded", () => {
                         modelSelect.value = currentSession.model;
                         console.warn(`Model ${currentSession.model} not found in fetched list. Added as unavailable option.`);
                     }
-                } else {
-                    const unityOptionExists = Array.from(modelSelect.options).some(option => option.value === "unity");
-                    if (unityOptionExists) {
-                        modelSelect.value = "unity";
-                    }
+                } else if (modelSelect.options.length > 0) {
+                    modelSelect.value = modelSelect.options[0].value;
                 }
             })
             .catch(err => {
@@ -199,13 +195,12 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
                 modelSelect.innerHTML = "";
                 const fallbackOpt = document.createElement("option");
-                fallbackOpt.value = "unity";
-                fallbackOpt.textContent = "unity";
+                fallbackOpt.value = "";
+                fallbackOpt.textContent = "No models available";
                 modelSelect.appendChild(fallbackOpt);
-                modelSelect.value = "unity";
 
                 const currentSession = Storage.getCurrentSession();
-                if (currentSession && currentSession.model && currentSession.model !== "unity") {
+                if (currentSession && currentSession.model) {
                     const sessOpt = document.createElement("option");
                     sessOpt.value = currentSession.model;
                     sessOpt.textContent = `${currentSession.model} (From Session - May Be Unavailable)`;


### PR DESCRIPTION
## Summary
- Use first available model when none selected instead of forcing Unity
- Drop Unity fallback in screensaver and storage utilities
- Make model dropdown generic without Unity-specific logic

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c0530ce3ac8329a6951e2e1a64449d