### PR TITLE
Remove Unity-specific defaults

### DIFF
--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/README.md
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/README.md
@@ -12,3 +12,11 @@ POLLINATIONS_API_TOKEN=your_token_here
 ```
 
 The application will automatically read this value at runtime and include it with all text requests.
+
+Alternatively, you can set the token in the browser console or application code using:
+
+```
+Storage.setToken("your_token_here");
+```
+
+The token is stored in `localStorage` and used for subsequent requests. Some models like `unity` require a token to respond.

--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/chat-init.js
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/chat-init.js
@@ -516,7 +516,7 @@ document.addEventListener("DOMContentLoaded", () => {
             lastUserMsg.includes("picture") || 
             imagePatterns.some(p => p.pattern.test(lastUserMsg))
         );
-        const selectedModel = modelSelect.value || currentSession.model || "unity";
+        const selectedModel = modelSelect.value || currentSession.model || modelSelect.options[0]?.value;
         const nonce = Date.now().toString() + Math.random().toString(36).substring(2);
         const body = { messages, model: selectedModel, nonce };
         let apiUrl = `https://text.pollinations.ai/openai`;
@@ -533,7 +533,12 @@ document.addEventListener("DOMContentLoaded", () => {
             cache: "no-store",
         })
             .then(res => {
-                if (!res.ok) throw new Error(`Pollinations error: ${res.status}`);
+                if (!res.ok) {
+                    if (res.status === 402) {
+                        throw new Error("Pollinations token required or tier too low for this model.");
+                    }
+                    throw new Error(`Pollinations error: ${res.status}`);
+                }
                 return res.json();
             })
             .then(data => {
@@ -589,7 +594,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
             })
             .catch(err => {
-                loadingDiv.textContent = "Error: Failed to get a response. Please try again.";
+                loadingDiv.textContent = err.message || "Error: Failed to get a response. Please try again.";
                 setTimeout(() => loadingDiv.remove(), 3000);
                 console.error("Error sending to Pollinations:", err);
                 if (callback) callback();

--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/chat-storage.js
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/chat-storage.js
@@ -550,7 +550,7 @@ document.addEventListener("DOMContentLoaded", () => {
             lastUserMsg.includes("picture") || 
             imagePatterns.some(p => p.pattern.test(lastUserMsg))
         );
-        const selectedModel = modelSelect.value || currentSession.model || "unity";
+        const selectedModel = modelSelect.value || currentSession.model || modelSelect.options[0]?.value;
         const nonce = Date.now().toString() + Math.random().toString(36).substring(2);
         const body = { messages, model: selectedModel, nonce };
         let apiUrl = `https://text.pollinations.ai/openai`;
@@ -566,7 +566,12 @@ document.addEventListener("DOMContentLoaded", () => {
             cache: "no-store",
         })
             .then(res => {
-                if (!res.ok) throw new Error(`Pollinations error: ${res.status}`);
+                if (!res.ok) {
+                    if (res.status === 402) {
+                        throw new Error("Pollinations token required or tier too low for this model.");
+                    }
+                    throw new Error(`Pollinations error: ${res.status}`);
+                }
                 return res.json();
             })
             .then(data => {
@@ -622,7 +627,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
             })
             .catch(err => {
-                loadingDiv.textContent = "Error: Failed to get a response. Please try again.";
+                loadingDiv.textContent = err.message || "Error: Failed to get a response. Please try again.";
                 setTimeout(() => loadingDiv.remove(), 3000);
                 console.error("Error sending to Pollinations:", err);
             });

--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/screensaver.js
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/screensaver.js
@@ -147,7 +147,7 @@ document.addEventListener("DOMContentLoaded", () => {
         ];
         const seed = generateSeed();
         const textModelSelect = document.getElementById("model-select");
-        const selectedModel = textModelSelect?.value || (window.Storage?.getCurrentSession?.().model) || "unity";
+        const selectedModel = textModelSelect?.value || window.Storage?.getCurrentSession?.().model || textModelSelect?.options?.[0]?.value;
 
         const body = { messages, model: selectedModel, nonce: Date.now().toString() + Math.random().toString(36).substring(2) };
         let apiUrl = `https://text.pollinations.ai/openai?seed=${seed}`;

--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/storage.js
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/storage.js
@@ -9,9 +9,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const sessionListEl = document.getElementById("session-list");
   let sessions = loadSessions();
-  const defaultModelPreference = localStorage.getItem("defaultModelPreference") || "unity";
+  const defaultModelPreference = localStorage.getItem("defaultModelPreference") || "";
 
   let envToken = "";
+  let storedToken = localStorage.getItem("pollinations_token") || "";
   (async () => {
     try {
       const res = await fetch(".env");
@@ -47,6 +48,7 @@ document.addEventListener("DOMContentLoaded", () => {
     getDefaultModel,
     setDefaultModel,
     getToken,
+    setToken,
     clearAllSessions,
     getMemories,
     addMemory,
@@ -61,7 +63,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function getDefaultModel() {
-    return localStorage.getItem("defaultModelPreference") || "unity";
+    return localStorage.getItem("defaultModelPreference") || "";
   }
 
   function setDefaultModel(modelName) {
@@ -70,7 +72,16 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function getToken() {
-    return envToken;
+    return storedToken || envToken;
+  }
+
+  function setToken(token) {
+    storedToken = token || "";
+    if (token) {
+      localStorage.setItem("pollinations_token", token);
+    } else {
+      localStorage.removeItem("pollinations_token");
+    }
   }
 
   function createSession(name) {

--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/ui.js
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/ui.js
@@ -163,10 +163,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
                 if (!hasValidModel) {
                     const fallbackOpt = document.createElement("option");
-                    fallbackOpt.value = "unity";
-                    fallbackOpt.textContent = "unity";
+                    fallbackOpt.value = "";
+                    fallbackOpt.textContent = "No models available";
                     modelSelect.appendChild(fallbackOpt);
-                    modelSelect.value = "unity";
                 }
 
                 const currentSession = Storage.getCurrentSession();
@@ -183,11 +182,8 @@ document.addEventListener("DOMContentLoaded", () => {
                         modelSelect.value = currentSession.model;
                         console.warn(`Model ${currentSession.model} not found in fetched list. Added as unavailable option.`);
                     }
-                } else {
-                    const unityOptionExists = Array.from(modelSelect.options).some(option => option.value === "unity");
-                    if (unityOptionExists) {
-                        modelSelect.value = "unity";
-                    }
+                } else if (modelSelect.options.length > 0) {
+                    modelSelect.value = modelSelect.options[0].value;
                 }
             })
             .catch(err => {
@@ -199,13 +195,12 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
                 modelSelect.innerHTML = "";
                 const fallbackOpt = document.createElement("option");
-                fallbackOpt.value = "unity";
-                fallbackOpt.textContent = "unity";
+                fallbackOpt.value = "";
+                fallbackOpt.textContent = "No models available";
                 modelSelect.appendChild(fallbackOpt);
-                modelSelect.value = "unity";
 
                 const currentSession = Storage.getCurrentSession();
-                if (currentSession && currentSession.model && currentSession.model !== "unity") {
+                if (currentSession && currentSession.model) {
                     const sessOpt = document.createElement("option");
                     sessOpt.value = currentSession.model;
                     sessOpt.textContent = `${currentSession.model} (From Session - May Be Unavailable)`;


### PR DESCRIPTION
## Summary
- Allow storing Pollinations API token in localStorage via `Storage.setToken`
- Surface clearer error when a model requires a token or higher tier
- Document localStorage token option for models like Unity

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c0530ce3ac8329a6951e2e1a64449d