### PR TITLE
Revert token storage changes and remove Authorization header

### DIFF
--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/README.md
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/README.md
@@ -12,11 +12,3 @@ POLLINATIONS_API_TOKEN=your_token_here
 ```
 
 The application will automatically read this value at runtime and include it with all text requests.
-
-Alternatively, you can set the token in the browser console or application code using:
-
-```
-Storage.setToken("your_token_here");
-```
-
-The token is stored in `localStorage` and used for subsequent requests. Some models like `unity` require a token to respond.

--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/chat-init.js
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/chat-init.js
@@ -516,7 +516,7 @@ document.addEventListener("DOMContentLoaded", () => {
             lastUserMsg.includes("picture") || 
             imagePatterns.some(p => p.pattern.test(lastUserMsg))
         );
-        const selectedModel = modelSelect.value || currentSession.model || modelSelect.options[0]?.value;
+        const selectedModel = modelSelect.value || currentSession.model || "unity";
         const nonce = Date.now().toString() + Math.random().toString(36).substring(2);
         const body = { messages, model: selectedModel, nonce };
         let apiUrl = `https://text.pollinations.ai/openai`;
@@ -525,7 +525,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
         console.log("Sending API request with payload:", JSON.stringify(body));
         const headers = { "Content-Type": "application/json", Accept: "application/json" };
-        if (token) headers["Authorization"] = `Bearer ${token}`;
         fetch(apiUrl, {
             method: "POST",
             headers,
@@ -533,12 +532,7 @@ document.addEventListener("DOMContentLoaded", () => {
             cache: "no-store",
         })
             .then(res => {
-                if (!res.ok) {
-                    if (res.status === 402) {
-                        throw new Error("Pollinations token required or tier too low for this model.");
-                    }
-                    throw new Error(`Pollinations error: ${res.status}`);
-                }
+                if (!res.ok) throw new Error(`Pollinations error: ${res.status}`);
                 return res.json();
             })
             .then(data => {
@@ -594,7 +588,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
             })
             .catch(err => {
-                loadingDiv.textContent = err.message || "Error: Failed to get a response. Please try again.";
+                loadingDiv.textContent = "Error: Failed to get a response. Please try again.";
                 setTimeout(() => loadingDiv.remove(), 3000);
                 console.error("Error sending to Pollinations:", err);
                 if (callback) callback();

--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/chat-storage.js
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/chat-storage.js
@@ -550,7 +550,7 @@ document.addEventListener("DOMContentLoaded", () => {
             lastUserMsg.includes("picture") || 
             imagePatterns.some(p => p.pattern.test(lastUserMsg))
         );
-        const selectedModel = modelSelect.value || currentSession.model || modelSelect.options[0]?.value;
+        const selectedModel = modelSelect.value || currentSession.model || "unity";
         const nonce = Date.now().toString() + Math.random().toString(36).substring(2);
         const body = { messages, model: selectedModel, nonce };
         let apiUrl = `https://text.pollinations.ai/openai`;
@@ -558,7 +558,6 @@ document.addEventListener("DOMContentLoaded", () => {
         if (token) apiUrl += `?token=${encodeURIComponent(token)}`;
         console.log("Sending API request with payload:", JSON.stringify(body));
         const headers = { "Content-Type": "application/json", Accept: "application/json" };
-        if (token) headers["Authorization"] = `Bearer ${token}`;
         fetch(apiUrl, {
             method: "POST",
             headers,
@@ -566,12 +565,7 @@ document.addEventListener("DOMContentLoaded", () => {
             cache: "no-store",
         })
             .then(res => {
-                if (!res.ok) {
-                    if (res.status === 402) {
-                        throw new Error("Pollinations token required or tier too low for this model.");
-                    }
-                    throw new Error(`Pollinations error: ${res.status}`);
-                }
+                if (!res.ok) throw new Error(`Pollinations error: ${res.status}`);
                 return res.json();
             })
             .then(data => {
@@ -627,7 +621,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
             })
             .catch(err => {
-                loadingDiv.textContent = err.message || "Error: Failed to get a response. Please try again.";
+                loadingDiv.textContent = "Error: Failed to get a response. Please try again.";
                 setTimeout(() => loadingDiv.remove(), 3000);
                 console.error("Error sending to Pollinations:", err);
             });

--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/screensaver.js
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/screensaver.js
@@ -147,7 +147,7 @@ document.addEventListener("DOMContentLoaded", () => {
         ];
         const seed = generateSeed();
         const textModelSelect = document.getElementById("model-select");
-        const selectedModel = textModelSelect?.value || window.Storage?.getCurrentSession?.().model || textModelSelect?.options?.[0]?.value;
+        const selectedModel = textModelSelect?.value || (window.Storage?.getCurrentSession?.().model) || "unity";
 
         const body = { messages, model: selectedModel, nonce: Date.now().toString() + Math.random().toString(36).substring(2) };
         let apiUrl = `https://text.pollinations.ai/openai?seed=${seed}`;
@@ -158,7 +158,6 @@ document.addEventListener("DOMContentLoaded", () => {
         for (let attempt = 1; attempt <= maxRetries; attempt++) {
             try {
                 const headers = { "Content-Type": "application/json", Accept: "application/json" };
-                if (token) headers["Authorization"] = `Bearer ${token}`;
                 const response = await fetch(apiUrl, {
                     method: "POST",
                     headers,

--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/storage.js
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/storage.js
@@ -9,10 +9,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const sessionListEl = document.getElementById("session-list");
   let sessions = loadSessions();
-  const defaultModelPreference = localStorage.getItem("defaultModelPreference") || "";
+  const defaultModelPreference = localStorage.getItem("defaultModelPreference") || "unity";
 
   let envToken = "";
-  let storedToken = localStorage.getItem("pollinations_token") || "";
   (async () => {
     try {
       const res = await fetch(".env");
@@ -48,7 +47,6 @@ document.addEventListener("DOMContentLoaded", () => {
     getDefaultModel,
     setDefaultModel,
     getToken,
-    setToken,
     clearAllSessions,
     getMemories,
     addMemory,
@@ -63,7 +61,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function getDefaultModel() {
-    return localStorage.getItem("defaultModelPreference") || "";
+    return localStorage.getItem("defaultModelPreference") || "unity";
   }
 
   function setDefaultModel(modelName) {
@@ -72,16 +70,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function getToken() {
-    return storedToken || envToken;
-  }
-
-  function setToken(token) {
-    storedToken = token || "";
-    if (token) {
-      localStorage.setItem("pollinations_token", token);
-    } else {
-      localStorage.removeItem("pollinations_token");
-    }
+    return envToken;
   }
 
   function createSession(name) {

--- a/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/ui.js
+++ b/Voice-and-Website-develop (15)/Voice-and-Website-develop/ai2/ui.js
@@ -163,9 +163,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
                 if (!hasValidModel) {
                     const fallbackOpt = document.createElement("option");
-                    fallbackOpt.value = "";
-                    fallbackOpt.textContent = "No models available";
+                    fallbackOpt.value = "unity";
+                    fallbackOpt.textContent = "unity";
                     modelSelect.appendChild(fallbackOpt);
+                    modelSelect.value = "unity";
                 }
 
                 const currentSession = Storage.getCurrentSession();
@@ -182,8 +183,11 @@ document.addEventListener("DOMContentLoaded", () => {
                         modelSelect.value = currentSession.model;
                         console.warn(`Model ${currentSession.model} not found in fetched list. Added as unavailable option.`);
                     }
-                } else if (modelSelect.options.length > 0) {
-                    modelSelect.value = modelSelect.options[0].value;
+                } else {
+                    const unityOptionExists = Array.from(modelSelect.options).some(option => option.value === "unity");
+                    if (unityOptionExists) {
+                        modelSelect.value = "unity";
+                    }
                 }
             })
             .catch(err => {
@@ -195,12 +199,13 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
                 modelSelect.innerHTML = "";
                 const fallbackOpt = document.createElement("option");
-                fallbackOpt.value = "";
-                fallbackOpt.textContent = "No models available";
+                fallbackOpt.value = "unity";
+                fallbackOpt.textContent = "unity";
                 modelSelect.appendChild(fallbackOpt);
+                modelSelect.value = "unity";
 
                 const currentSession = Storage.getCurrentSession();
-                if (currentSession && currentSession.model) {
+                if (currentSession && currentSession.model && currentSession.model !== "unity") {
                     const sessOpt = document.createElement("option");
                     sessOpt.value = currentSession.model;
                     sessOpt.textContent = `${currentSession.model} (From Session - May Be Unavailable)`;


### PR DESCRIPTION
## Summary
- Revert prior merges so the app again reads the Pollinations API token from a `.env` file and defaults models to `unity`.
- Drop Authorization headers in chat and screensaver requests; the Pollinations token is now only passed via the `token` query parameter.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c0593037d08329abd0d98ffd932b94